### PR TITLE
Fixes to support higher DRBD version and enabled SecureBoot

### DIFF
--- a/openapi/values.yaml
+++ b/openapi/values.yaml
@@ -16,6 +16,9 @@ properties:
       drbdVersion:
         type: string
         default: "9.2.5"
+      drbdVersionForceRebuild:
+        type: string
+        default: "9.2.4"
       dataNodesChecksum:
         type: string
         default: "default_data_nodes_checksum"

--- a/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -74,6 +74,7 @@ spec:
 
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
       desired_version="{{ $.Values.sdsDrbd.internal.drbdVersion }}"
+      force_rebuild_version="{{ $.Values.sdsDrbd.internal.drbdVersionForceRebuild }}"
 
       # We expect the loaded DRBD module to be version 9.
       # If version 8 is loaded, it means that for some reason, the in-tree kernel module has been automatically loaded.
@@ -85,7 +86,9 @@ spec:
         rmmod drbd || true
       fi
 
-      if [ "${current_version}" == "${desired_version}" ]; then
+      if { echo "${current_version}"; echo "${force_rebuild_version}"; } | sort --version-sort --check; then
+        echo "DRBD needs to be rebuilt"
+      else
         if grep -q -E '^drbd$' /etc/modules; then
           sed -i '/^drbd$/d' /etc/modules
         fi
@@ -96,8 +99,13 @@ spec:
       fi
     fi
 
+    apt-get -y install make gcc bind-utils patch mokutil
+    check_sb_state="$(mokutil --sb-state)"
+    if [[ "$check_sb_state" == "SecureBoot enabled" ]]; then
+      echo "SecureBoot is enabled. Please manually install DRBD version  {{ $.Values.sdsDrbd.internal.drbdVersion }} or higher."
+      exit 0
+    fi
     bb-rp-install "drbd:{{ .Values.global.modulesImages.digests.registrypackages.drbd }}"
-    apt-get -y install make gcc bind-utils patch
 
     attempt=0
     until SPAAS_IP="$(host -t A "$SPAAS_FQDN" "$CLUSTER_DNS" | awk '/has address/ { print $4 }')"
@@ -148,9 +156,10 @@ spec:
     if [ -e "/proc/drbd" ]; then
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
       desired_version="{{ $.Values.sdsDrbd.internal.drbdVersion }}"
+      force_rebuild_version="{{ $.Values.sdsDrbd.internal.drbdVersionForceRebuild }}"
 
-      if [ "${current_version}" != "${desired_version}" ]; then
-        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired "$desired_version"), setting reboot flag"
+      if { echo "${current_version}"; echo "${force_rebuild_version}"; } | sort --version-sort --check; then
+        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired minimum "$desired_version"), setting reboot flag"
         bb-flag-set reboot
       fi
     fi

--- a/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -79,6 +79,7 @@ spec:
 
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
       desired_version="{{ $.Values.sdsDrbd.internal.drbdVersion }}"
+      force_rebuild_version="{{ $.Values.sdsDrbd.internal.drbdVersionForceRebuild }}"
 
       # We expect the loaded DRBD module to be version 9.
       # If version 8 is loaded, it means that for some reason, the in-tree kernel module has been automatically loaded.
@@ -90,7 +91,9 @@ spec:
         rmmod drbd || true
       fi
 
-      if [ "${current_version}" == "${desired_version}" ]; then
+      if { echo "${current_version}"; echo "${force_rebuild_version}"; } | sort --version-sort --check; then
+        echo "DRBD needs to be rebuilt"
+      else
         if grep -q -E '^drbd$' /etc/modules; then
           sed -i '/^drbd$/d' /etc/modules
         fi
@@ -101,8 +104,13 @@ spec:
       fi
     fi
 
+    bb-yum-install make gcc bind-utils patch mokutil
+    check_sb_state="$(mokutil --sb-state)"
+    if [[ "$check_sb_state" == "SecureBoot enabled" ]]; then
+      echo "SecureBoot is enabled. Please manually install DRBD version  {{ $.Values.sdsDrbd.internal.drbdVersion }} or higher."
+      exit 0
+    fi
     bb-rp-install "drbd:{{ .Values.global.modulesImages.digests.registrypackages.drbd }}"
-    bb-yum-install make gcc bind-utils patch
 
     attempt=0
     until SPAAS_IP="$(host -t A "$SPAAS_FQDN" "$CLUSTER_DNS" | awk '/has address/ { print $4 }')"
@@ -153,9 +161,10 @@ spec:
     if [ -e "/proc/drbd" ]; then
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
       desired_version="{{ $.Values.sdsDrbd.internal.drbdVersion }}"
+      force_rebuild_version="{{ $.Values.sdsDrbd.internal.drbdVersionForceRebuild }}"
 
-      if [ "${current_version}" != "${desired_version}" ]; then
-        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired "$desired_version"), setting reboot flag"
+      if { echo "${current_version}"; echo "${force_rebuild_version}"; } | sort --version-sort --check; then
+        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired minimum "$desired_version"), setting reboot flag"
         bb-flag-set reboot
       fi
     fi

--- a/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -76,6 +76,7 @@ spec:
 
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
       desired_version="{{ $.Values.sdsDrbd.internal.drbdVersion }}"
+      force_rebuild_version="{{ $.Values.sdsDrbd.internal.drbdVersionForceRebuild }}"
 
       # We expect the loaded DRBD module to be version 9.
       # If version 8 is loaded, it means that for some reason, the in-tree kernel module has been automatically loaded.
@@ -87,7 +88,9 @@ spec:
         rmmod drbd || true
       fi
 
-      if [ "${current_version}" == "${desired_version}" ]; then
+      if { echo "${current_version}"; echo "${force_rebuild_version}"; } | sort --version-sort --check; then
+        echo "DRBD needs to be rebuilt"
+      else
         if grep -q -E '^drbd$' /etc/modules; then
           sed -i '/^drbd$/d' /etc/modules
         fi
@@ -98,8 +101,13 @@ spec:
       fi
     fi
 
+    bb-apt-install make gcc bind9-host patch mokutil
+    check_sb_state="$(mokutil --sb-state)"
+    if [[ "$check_sb_state" == "SecureBoot enabled" ]]; then
+      echo "SecureBoot is enabled. Please manually install DRBD version  {{ $.Values.sdsDrbd.internal.drbdVersion }} or higher."
+      exit 0
+    fi
     bb-rp-install "drbd:{{ .Values.global.modulesImages.digests.registrypackages.drbd }}"
-    bb-apt-install make gcc bind9-host patch
 
     attempt=0
     until SPAAS_IP="$(host -t A "$SPAAS_FQDN" "$CLUSTER_DNS" | awk '/has address/ { print $4 }')"
@@ -150,9 +158,10 @@ spec:
     if [ -e "/proc/drbd" ]; then
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
       desired_version="{{ $.Values.sdsDrbd.internal.drbdVersion }}"
+      force_rebuild_version="{{ $.Values.sdsDrbd.internal.drbdVersionForceRebuild }}"
 
-      if [ "${current_version}" != "${desired_version}" ]; then
-        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired "$desired_version"), setting reboot flag"
+      if { echo "${current_version}"; echo "${force_rebuild_version}"; } | sort --version-sort --check; then
+        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired minimum "$desired_version"), setting reboot flag"
         bb-flag-set reboot
       fi
     fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR helps to avoid potential issues and cyclic reboots in case of:
- Enabled SecureBoot
- Version DRBD higher then desired on cluster nodes

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

There is possibility of node cycle reboot in case of
- SecureBoot enabled
- Version DRBD higher then desired on cluster nodes

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct bashible behavior

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
