### PR TITLE
[drbd] Apply multiple fixes in NodeGroupConfigurations

### DIFF
--- a/images/semver/scripts/install
+++ b/images/semver/scripts/install
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeo pipefail
+mkdir -p /opt/deckhouse/bin
+cp -f d8-semver /opt/deckhouse/bin

--- a/images/semver/scripts/uninstall
+++ b/images/semver/scripts/uninstall
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rm -rf /opt/deckhouse/bin/d8-semver

--- a/images/semver/werf.inc.yaml
+++ b/images/semver/werf.inc.yaml
@@ -1,0 +1,33 @@
+{{- $version := "3.4.0" }}
+---
+image: {{ $.ImageName }}
+from: "registry.deckhouse.io/base_images/scratch@sha256:b054705fcc9f2205777d80a558d920c0b4209efdc3163c22b5bfcb5dda1db5fc"
+
+import:
+  - artifact: {{ $.ImageName }}-artifact
+    add: /
+    to: /
+    includePaths:
+      - d8-semver
+      - install
+      - uninstall
+    before: setup
+docker:
+  LABEL:
+    distro: all
+    version: all
+    semver: {{ $version }}
+---
+artifact: {{ $.ImageName }}-artifact
+from: "registry.deckhouse.io/base_images/alpine:3.16.3@sha256:5548e9172c24a1b0ca9afdd2bf534e265c94b12b36b3e0c0302f5853eaf00abb"
+
+git:
+  - add: /images/{{ $.ImageName }}/scripts
+    to: /
+
+shell:
+  setup:
+    - apk add wget tar
+    - wget https://github.com/fsaintjacques/semver-tool/archive/refs/tags/{{ $version }}.tar.gz
+    - tar -xvf {{ $version }}.tar.gz
+    - mv semver-tool-{{ $version }}/src/semver /d8-semver

--- a/openapi/config-values.yaml
+++ b/openapi/config-values.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  # TODO: Set the option below to deprecated when the PR https://github.com/deckhouse/deckhouse/pull/7263 will reach RockSolid channel
+  registryScheme:
+    type: string
+    description: Change this parameter to "http" if the module registry does not support TLS.
+    default: https
   logLevel:
     type: string
     enum:

--- a/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -25,6 +25,19 @@ spec:
     # data nodes checksum to force bashible execution on nodes list change
     # {{ $.Values.sdsDrbd.internal.dataNodesChecksum }}
 
+    # Unpack package from module image and run install script
+    # bb-rp-from-module-image-install package:digest registry_auth scheme registry_address registry_path
+    # TODO: Get rid of this in favour of standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
+    bb-rp-from-module-image-install() {
+      local MODULE_PACKAGE=$1
+      local REGISTRY_AUTH=$2
+      local SCHEME=$3
+      local REGISTRY_ADDRESS=$4
+      local REGISTRY_PATH=$5
+    
+      bb-rp-install $MODULE_PACKAGE
+    }
+
     kubeconfig="/etc/kubernetes/kubelet.conf"
 
     kernel_version_in_use="$(uname -r)"
@@ -69,6 +82,11 @@ spec:
     CLUSTER_DNS="{{ .Values.global.discovery.clusterDNSAddress }}"
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
+    MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsDrbd.registry.dockercfg }} | base64 -d | jq -r .auths[].auth | base64 -d)"
+    MODULE_SCHEME="{{ .Values.sdsDrbd.registryScheme }}"
+    MODULE_REGISTRY_ADDRESS=$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 1 -d '/')
+    MODULE_REGISTRY_PATH="/"$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 2- -d '/')"/sds-drbd"
+
     if [ -e "/proc/drbd" ]; then
       # DRBD check version
 
@@ -85,7 +103,12 @@ spec:
         rmmod drbd || true
       fi
 
-      if [ "${current_version}" == "${desired_version}" ]; then
+      # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
+      bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsDrbd.semver }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
+
+      if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
+        bb-log-info "DRBD needs to be rebuilt"
+      else
         if grep -q -E '^drbd$' /etc/modules; then
           sed -i '/^drbd$/d' /etc/modules
         fi
@@ -96,8 +119,15 @@ spec:
       fi
     fi
 
-    bb-rp-install "drbd:{{ .Values.global.modulesImages.digests.registrypackages.drbd }}"
-    apt-get -y install make gcc bind-utils patch
+    apt-get -y install make gcc bind-utils patch mokutil
+    check_sb_state="$(mokutil --sb-state || echo "Not supported")"
+    if [[ "$check_sb_state" == "SecureBoot enabled" ]]; then
+      bb-log-info "SecureBoot is enabled. Please manually install DRBD version  {{ $.Values.sdsDrbd.internal.drbdVersion }} or higher."
+      exit 0
+    fi
+
+    # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
+    bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsDrbd.drbd }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
 
     attempt=0
     until SPAAS_IP="$(host -t A "$SPAAS_FQDN" "$CLUSTER_DNS" | awk '/has address/ { print $4 }')"
@@ -149,8 +179,8 @@ spec:
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
       desired_version="{{ $.Values.sdsDrbd.internal.drbdVersion }}"
 
-      if [ "${current_version}" != "${desired_version}" ]; then
-        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired "$desired_version"), setting reboot flag"
+      if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
+        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired minimum "$desired_version"), setting reboot flag"
         bb-flag-set reboot
       fi
     fi

--- a/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -25,6 +25,19 @@ spec:
     # data nodes checksum to force bashible execution on nodes list change
     # {{ $.Values.sdsDrbd.internal.dataNodesChecksum }}
 
+    # Unpack package from module image and run install script
+    # bb-rp-from-module-image-install package:digest registry_auth scheme registry_address registry_path
+    # TODO: Get rid of this in favour of standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
+    bb-rp-from-module-image-install() {
+      local MODULE_PACKAGE=$1
+      local REGISTRY_AUTH=$2
+      local SCHEME=$3
+      local REGISTRY_ADDRESS=$4
+      local REGISTRY_PATH=$5
+    
+      bb-rp-install $MODULE_PACKAGE
+    }
+
     kubeconfig="/etc/kubernetes/kubelet.conf"
 
     kernel_version_in_use="$(uname -r)"
@@ -74,6 +87,11 @@ spec:
     CLUSTER_DNS="{{ .Values.global.discovery.clusterDNSAddress }}"
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
+    MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsDrbd.registry.dockercfg }} | base64 -d | jq -r .auths[].auth | base64 -d)"
+    MODULE_SCHEME="{{ .Values.sdsDrbd.registryScheme }}"
+    MODULE_REGISTRY_ADDRESS=$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 1 -d '/')
+    MODULE_REGISTRY_PATH="/"$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 2- -d '/')"/sds-drbd"
+
     if [ -e "/proc/drbd" ]; then
       # DRBD check version
 
@@ -90,7 +108,12 @@ spec:
         rmmod drbd || true
       fi
 
-      if [ "${current_version}" == "${desired_version}" ]; then
+      # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
+      bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsDrbd.semver }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
+
+      if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
+        bb-log-info "DRBD needs to be rebuilt"
+      else
         if grep -q -E '^drbd$' /etc/modules; then
           sed -i '/^drbd$/d' /etc/modules
         fi
@@ -101,8 +124,15 @@ spec:
       fi
     fi
 
-    bb-rp-install "drbd:{{ .Values.global.modulesImages.digests.registrypackages.drbd }}"
-    bb-yum-install make gcc bind-utils patch
+    bb-yum-install make gcc bind-utils patch mokutil
+    check_sb_state="$(mokutil --sb-state || echo "Not supported")"
+    if [[ "$check_sb_state" == "SecureBoot enabled" ]]; then
+      bb-log-info "SecureBoot is enabled. Please manually install DRBD version  {{ $.Values.sdsDrbd.internal.drbdVersion }} or higher."
+      exit 0
+    fi
+
+    # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
+    bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsDrbd.drbd }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
 
     attempt=0
     until SPAAS_IP="$(host -t A "$SPAAS_FQDN" "$CLUSTER_DNS" | awk '/has address/ { print $4 }')"
@@ -154,8 +184,8 @@ spec:
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
       desired_version="{{ $.Values.sdsDrbd.internal.drbdVersion }}"
 
-      if [ "${current_version}" != "${desired_version}" ]; then
-        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired "$desired_version"), setting reboot flag"
+      if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
+        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired minimum "$desired_version"), setting reboot flag"
         bb-flag-set reboot
       fi
     fi

--- a/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -25,6 +25,19 @@ spec:
     # data nodes checksum to force bashible execution on nodes list change
     # {{ $.Values.sdsDrbd.internal.dataNodesChecksum }}
 
+    # Unpack package from module image and run install script
+    # bb-rp-from-module-image-install package:digest registry_auth scheme registry_address registry_path
+    # TODO: Get rid of this in favour of standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
+    bb-rp-from-module-image-install() {
+      local MODULE_PACKAGE=$1
+      local REGISTRY_AUTH=$2
+      local SCHEME=$3
+      local REGISTRY_ADDRESS=$4
+      local REGISTRY_PATH=$5
+    
+      bb-rp-install $MODULE_PACKAGE
+    }
+
     kubeconfig="/etc/kubernetes/kubelet.conf"
 
     kernel_version_in_use="$(uname -r)"
@@ -71,6 +84,11 @@ spec:
     CLUSTER_DNS="{{ .Values.global.discovery.clusterDNSAddress }}"
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
+    MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsDrbd.registry.dockercfg }} | base64 -d | jq -r .auths[].auth | base64 -d)"
+    MODULE_SCHEME="{{ .Values.sdsDrbd.registryScheme }}"
+    MODULE_REGISTRY_ADDRESS=$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 1 -d '/')
+    MODULE_REGISTRY_PATH="/"$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 2- -d '/')"/sds-drbd"
+
     if [ -e "/proc/drbd" ]; then
       # DRBD check version
 
@@ -87,7 +105,12 @@ spec:
         rmmod drbd || true
       fi
 
-      if [ "${current_version}" == "${desired_version}" ]; then
+      # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
+      bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsDrbd.semver }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
+
+      if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
+        bb-log-info "DRBD needs to be rebuilt"
+      else
         if grep -q -E '^drbd$' /etc/modules; then
           sed -i '/^drbd$/d' /etc/modules
         fi
@@ -98,8 +121,15 @@ spec:
       fi
     fi
 
-    bb-rp-install "drbd:{{ .Values.global.modulesImages.digests.registrypackages.drbd }}"
-    bb-apt-install make gcc bind9-host patch
+    bb-apt-install make gcc bind9-host patch mokutil
+    check_sb_state="$(mokutil --sb-state || echo "Not supported")"
+    if [[ "$check_sb_state" == "SecureBoot enabled" ]]; then
+      bb-log-info "SecureBoot is enabled. Please manually install DRBD version  {{ $.Values.sdsDrbd.internal.drbdVersion }} or higher."
+      exit 0
+    fi
+    
+    # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
+    bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsDrbd.drbd }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
 
     attempt=0
     until SPAAS_IP="$(host -t A "$SPAAS_FQDN" "$CLUSTER_DNS" | awk '/has address/ { print $4 }')"
@@ -151,8 +181,8 @@ spec:
       current_version="$(cat /proc/drbd | grep 'version:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
       desired_version="{{ $.Values.sdsDrbd.internal.drbdVersion }}"
 
-      if [ "${current_version}" != "${desired_version}" ]; then
-        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired "$desired_version"), setting reboot flag"
+      if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
+        bb-log-info "Non-actual version of drbd is loaded (now "$current_version", desired minimum "$desired_version"), setting reboot flag"
         bb-flag-set reboot
       fi
     fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Several changes to NodeGroupConfigurations:
- Added an exception when SecureBoot is enabled (a message about the need for manual maintenance of the DRBD module).
- Checking the DRBD version using semver to avoid rebuilding DRBD if a newer version of DRBD is installed than the one in the module image.
- Added a temporary function to install software packages from embedded module images (will be replaced by built-in Deckhouse functionality).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

There may be several scenarios in which cyclic rebuilding of DRBD and node rebooting can occur.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct DRBD version check and avoid problems while SecureBoot is enabled

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
