### PR TITLE
[controller] Correct annotation of DRBDPVWithIncorrectSettings alert

### DIFF
--- a/monitoring/prometheus-rules/drbd-pv-with-incorrect-settings.yaml
+++ b/monitoring/prometheus-rules/drbd-pv-with-incorrect-settings.yaml
@@ -9,8 +9,8 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_drbd_device_health: "DRBDPVWithIncorrectSettings,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_drbd_device_health: "DRBDPVWithIncorrectSettings,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_drbd_device_health: "DRBDPVSettingsCheck,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_drbd_device_health: "DRBDPVSettingsCheck,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: DRBD PVs has incorrect settings
         description: |
           There are persistent volumes in the cluster that were created before migration to DRBDStorageClass. 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Annotation of DRBDPVWithIncorrectSettings alert has been corrected

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

There is grouping problem because of incorrect annotation

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct alerts grouping

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
