### PR TITLE
[controller] Fix in auth parsing and bb-rp-from-module-image-install function usage

### DIFF
--- a/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml
@@ -82,7 +82,7 @@ spec:
     CLUSTER_DNS="{{ .Values.global.discovery.clusterDNSAddress }}"
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
-    MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsDrbd.registry.dockercfg }} | base64 -d | jq -r .auths[].auth | base64 -d)"
+    MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsDrbd.registry.dockercfg }} | base64 -d | jq -r '.auths[].auth // ""' | base64 -d)"
     MODULE_SCHEME="{{ .Values.sdsDrbd.registryScheme }}"
     MODULE_REGISTRY_ADDRESS=$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 1 -d '/')
     MODULE_REGISTRY_PATH="/"$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 2- -d '/')"/sds-drbd"
@@ -104,7 +104,7 @@ spec:
       fi
 
       # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
-      bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsDrbd.semver }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
+      bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsDrbd.semver }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
 
       if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
         bb-log-info "DRBD needs to be rebuilt"
@@ -127,7 +127,7 @@ spec:
     fi
 
     # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
-    bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsDrbd.drbd }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
+    bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsDrbd.drbd }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
 
     attempt=0
     until SPAAS_IP="$(host -t A "$SPAAS_FQDN" "$CLUSTER_DNS" | awk '/has address/ { print $4 }')"

--- a/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-centos-like.yaml
@@ -87,7 +87,7 @@ spec:
     CLUSTER_DNS="{{ .Values.global.discovery.clusterDNSAddress }}"
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
-    MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsDrbd.registry.dockercfg }} | base64 -d | jq -r .auths[].auth | base64 -d)"
+    MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsDrbd.registry.dockercfg }} | base64 -d | jq -r '.auths[].auth // ""' | base64 -d)"
     MODULE_SCHEME="{{ .Values.sdsDrbd.registryScheme }}"
     MODULE_REGISTRY_ADDRESS=$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 1 -d '/')
     MODULE_REGISTRY_PATH="/"$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 2- -d '/')"/sds-drbd"
@@ -109,7 +109,7 @@ spec:
       fi
 
       # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
-      bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsDrbd.semver }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
+      bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsDrbd.semver }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
 
       if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
         bb-log-info "DRBD needs to be rebuilt"
@@ -132,7 +132,7 @@ spec:
     fi
 
     # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
-    bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsDrbd.drbd }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
+    bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsDrbd.drbd }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
 
     attempt=0
     until SPAAS_IP="$(host -t A "$SPAAS_FQDN" "$CLUSTER_DNS" | awk '/has address/ { print $4 }')"

--- a/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
+++ b/templates/nodegroupconfiguration-drbd-install-debian-like.yaml
@@ -84,7 +84,7 @@ spec:
     CLUSTER_DNS="{{ .Values.global.discovery.clusterDNSAddress }}"
     SPAAS_FQDN="spaas.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}"
 
-    MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsDrbd.registry.dockercfg }} | base64 -d | jq -r .auths[].auth | base64 -d)"
+    MODULE_REGISTRY_AUTH="$(echo {{ .Values.sdsDrbd.registry.dockercfg }} | base64 -d | jq -r '.auths[].auth // ""' | base64 -d)"
     MODULE_SCHEME="{{ .Values.sdsDrbd.registryScheme }}"
     MODULE_REGISTRY_ADDRESS=$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 1 -d '/')
     MODULE_REGISTRY_PATH="/"$(echo {{ .Values.sdsDrbd.registry.base }} | cut -f 2- -d '/')"/sds-drbd"
@@ -106,7 +106,7 @@ spec:
       fi
 
       # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
-      bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsDrbd.semver }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
+      bb-rp-from-module-image-install "semver:{{ .Values.global.modulesImages.digests.sdsDrbd.semver }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
 
       if [ "$(d8-semver compare $current_version $desired_version)" == "-1" ]; then
         bb-log-info "DRBD needs to be rebuilt"
@@ -129,7 +129,7 @@ spec:
     fi
     
     # TODO: Change this to standard bb-rp-module-install when there will be Deckhouse 1.58 release on RockSolid channel
-    bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsDrbd.drbd }}" $MODULE_REGISTRY_AUTH $MODULE_SCHEME $MODULE_REGISTRY_ADDRESS $MODULE_REGISTRY_PATH
+    bb-rp-from-module-image-install "drbd:{{ .Values.global.modulesImages.digests.sdsDrbd.drbd }}" "$MODULE_REGISTRY_AUTH" "$MODULE_SCHEME" "$MODULE_REGISTRY_ADDRESS" "$MODULE_REGISTRY_PATH"
 
     attempt=0
     until SPAAS_IP="$(host -t A "$SPAAS_FQDN" "$CLUSTER_DNS" | awk '/has address/ { print $4 }')"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR fixes some case of incorrect dockercfg parsing, while preparing for module images pull

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Now there is problem in CE version

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Module images pulling works correctly

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
