### PR TITLE
[controller] Fix array initialization

### DIFF
--- a/images/sds-drbd-controller/pkg/controller/linstor_node.go
+++ b/images/sds-drbd-controller/pkg/controller/linstor_node.go
@@ -387,6 +387,10 @@ func GetLinstorNodes(ctx context.Context, lc *lclient.Client) ([]lclient.Node, [
 	linstorControllerNodes := make([]lclient.Node, 0, len(linstorNodes))
 	linstorSatelliteNodes := make([]lclient.Node, 0, len(linstorNodes))
 
+	//TODO: 1
+	// TODO: 2
+	// TODO: 3
+
 	for _, linstorNode := range linstorNodes {
 		if linstorNode.Type == LinstorControllerType {
 			linstorControllerNodes = append(linstorControllerNodes, linstorNode)

--- a/images/sds-drbd-controller/pkg/controller/linstor_node.go
+++ b/images/sds-drbd-controller/pkg/controller/linstor_node.go
@@ -387,10 +387,6 @@ func GetLinstorNodes(ctx context.Context, lc *lclient.Client) ([]lclient.Node, [
 	linstorControllerNodes := make([]lclient.Node, 0, len(linstorNodes))
 	linstorSatelliteNodes := make([]lclient.Node, 0, len(linstorNodes))
 
-	//TODO: 1
-	// TODO: 2
-	// TODO: 3
-
 	for _, linstorNode := range linstorNodes {
 		if linstorNode.Type == LinstorControllerType {
 			linstorControllerNodes = append(linstorControllerNodes, linstorNode)

--- a/images/sds-drbd-controller/pkg/controller/linstor_node.go
+++ b/images/sds-drbd-controller/pkg/controller/linstor_node.go
@@ -384,8 +384,8 @@ func GetLinstorNodes(ctx context.Context, lc *lclient.Client) ([]lclient.Node, [
 		return nil, nil, err
 	}
 
-	linstorControllerNodes := make([]lclient.Node, len(linstorNodes))
-	linstorSatelliteNodes := make([]lclient.Node, len(linstorNodes))
+	linstorControllerNodes := make([]lclient.Node, 0, len(linstorNodes))
+	linstorSatelliteNodes := make([]lclient.Node, 0, len(linstorNodes))
 
 	for _, linstorNode := range linstorNodes {
 		if linstorNode.Type == LinstorControllerType {


### PR DESCRIPTION
## Description
Fixed slice of nodes initialization to prevent empty nodes deletion.

## Why do we need it, and what problem does it solve?
Because slice of nodes was initialized with len and then actual nodes were appended to the end of the slice, it goes to errors with attempts to delete nodes with empty names.

## What is the expected result?
No more error logs about  "Remove LINSTOR controller node" with empty names.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
