### PR TITLE
[controller] Adapt Python hooks for Deckhouse pod's switch to Alt Linux

### DIFF
--- a/.werf/python-deps.yaml
+++ b/.werf/python-deps.yaml
@@ -2,7 +2,7 @@
 ---
 image: python-dependencies
 from: registry.deckhouse.io/base_images/alpine:3.16.3
-fromCacheVersion: 2023-12-13
+fromCacheVersion: 2024-02-14
 git:
   - add: /
     to: /

--- a/hooks/lib/certificate/certificate.py
+++ b/hooks/lib/certificate/certificate.py
@@ -81,8 +81,8 @@ class Certificate:
     def add_extension(self, type_name: str,
                       critical: bool,
                       value: str,
-                      subject: crypto.Optional["X509"] = None,
-                      issuer: crypto.Optional["X509"] = None):
+                      subject: crypto.X509 = None,
+                      issuer: crypto.X509 = None):
         """
         Adds extensions to certificate.
         :param type_name: The name of the type of extension_ to create.
@@ -97,10 +97,10 @@ class Certificate:
         :type value: :py:class:`str`
 
         :param subject: Optional X509 certificate to use as subject.
-        :type subject: :py:class:`crypto.Optional["X509"]`
+        :type subject: :py:class:`crypto.X509`
 
         :param issuer: Optional X509 certificate to use as issuer.
-        :type issuer: :py:class:`crypto.Optional["X509"]`
+        :type issuer: :py:class:`crypto.X509`
         """ 
         ext = crypto.X509Extension(type_name=str.encode(type_name),
                                    critical=critical,

--- a/lib/python/requirements.txt
+++ b/lib/python/requirements.txt
@@ -1,11 +1,11 @@
 cffi==1.16.0
-cryptography==41.0.4
+cryptography==42.0.2
 DateTime==5.2
 deckhouse==0.4.9
 dictdiffer==0.9.0
 dotmap==1.3.30
 pycparser==2.21
-pyOpenSSL==23.2.0
+pyOpenSSL==24.0.0
 pytz==2023.3.post1
 PyYAML==6.0.1
 zope.interface==6.0


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR fixes the hooks-related issues caused by Python module updates.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Hooks broken because of module update

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Properly working hooks
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
